### PR TITLE
Missing end quote

### DIFF
--- a/config/junk
+++ b/config/junk
@@ -4,7 +4,7 @@ description: Used for unwanted newsgroups
 groups: junk.*
 comment: [
     "The junk newsgroup is reserved by RFC 5536 and MUST NOT be used.  It"
-    "is used by some implementations to store messages to unwanted
+    "is used by some implementations to store messages to unwanted"
     "newsgroups.  The junk.* hierarchy is not reserved by RFC 5536, but"
     "it's marked reserved here because, given the special meaning of the"
     "junk group, using it for any other purpose would be confusing and"


### PR DESCRIPTION
This otherwise leads to a trailing space at the end of the resulted control.ctl file.